### PR TITLE
fix: prevent status overwrite without user consent

### DIFF
--- a/src/main/java/com/statusbeat/statusbeat/model/User.java
+++ b/src/main/java/com/statusbeat/statusbeat/model/User.java
@@ -49,6 +49,9 @@ public class User {
 
     private boolean manualStatusSet; // Flag indicating user manually changed their status
 
+    @Builder.Default
+    private boolean statusCleared = true; // True when no StatusBeat status is set
+
     // Token invalidation tracking
     private boolean tokenInvalidated; // Flag indicating Slack or Spotify token has been revoked
 

--- a/src/main/java/com/statusbeat/statusbeat/model/UserSettings.java
+++ b/src/main/java/com/statusbeat/statusbeat/model/UserSettings.java
@@ -29,6 +29,9 @@ public class UserSettings {
     private boolean syncEnabled = true;
 
     @Builder.Default
+    private boolean syncActive = false;  // User must explicitly start sync
+
+    @Builder.Default
     private String defaultEmoji = ":musical_note:";
 
     @Builder.Default

--- a/src/main/java/com/statusbeat/statusbeat/service/AppHomeService.java
+++ b/src/main/java/com/statusbeat/statusbeat/service/AppHomeService.java
@@ -107,8 +107,9 @@ public class AppHomeService {
                         ),
                         section(section -> section
                                 .text(markdownText(
-                                        String.format("*Status:* %s\n*Emoji:* %s\n*Show Artist:* %s\n*Show Title:* %s",
+                                        String.format("*Status:* %s\n*Sync:* %s\n*Emoji:* %s\n*Show Artist:* %s\n*Show Title:* %s",
                                                 settings.isSyncEnabled() ? ":white_check_mark: Enabled" : ":no_entry: Disabled",
+                                                getSyncStateDisplay(settings),
                                                 settings.getDefaultEmoji(),
                                                 settings.isShowArtist() ? "Yes" : "No",
                                                 settings.isShowSongTitle() ? "Yes" : "No"
@@ -215,18 +216,15 @@ public class AppHomeService {
                             )
                     ))
             );
-        } else {
+        } else if (!settings.isSyncEnabled()) {
+            // Sync is disabled - show enable button
             return actions(actions -> actions
                     .blockId("home_actions")
                     .elements(asElements(
                             button(button -> button
-                                    .actionId(settings.isSyncEnabled() ? "disable_sync" : "enable_sync")
-                                    .text(plainText(settings.isSyncEnabled() ? "Disable Sync" : "Enable Sync"))
-                                    .style(settings.isSyncEnabled() ? "danger" : "primary")
-                            ),
-                            button(button -> button
-                                    .actionId("manual_sync")
-                                    .text(plainText("Sync Now"))
+                                    .actionId("enable_sync")
+                                    .text(plainText("Enable Sync"))
+                                    .style("primary")
                             ),
                             button(button -> button
                                     .actionId("configure_emoji")
@@ -242,6 +240,44 @@ public class AppHomeService {
                             )
                     ))
             );
+        } else {
+            // Sync is enabled - show start/stop and disable buttons
+            return actions(actions -> actions
+                    .blockId("home_actions")
+                    .elements(asElements(
+                            button(button -> button
+                                    .actionId(settings.isSyncActive() ? "stop_sync" : "start_sync")
+                                    .text(plainText(settings.isSyncActive() ? "Stop Sync" : "Start Sync"))
+                                    .style(settings.isSyncActive() ? "danger" : "primary")
+                            ),
+                            button(button -> button
+                                    .actionId("disable_sync")
+                                    .text(plainText("Disable"))
+                            ),
+                            button(button -> button
+                                    .actionId("configure_emoji")
+                                    .text(plainText("Configure Emoji"))
+                            ),
+                            button(button -> button
+                                    .actionId("configure_working_hours")
+                                    .text(plainText("Working Hours"))
+                            ),
+                            button(button -> button
+                                    .actionId("configure_devices")
+                                    .text(plainText("Select Devices"))
+                            )
+                    ))
+            );
+        }
+    }
+
+    private String getSyncStateDisplay(UserSettings settings) {
+        if (!settings.isSyncEnabled()) {
+            return ":no_entry: Disabled";
+        } else if (settings.isSyncActive()) {
+            return ":arrow_forward: Syncing";
+        } else {
+            return ":double_vertical_bar: Paused";
         }
     }
 }

--- a/src/main/java/com/statusbeat/statusbeat/slack/AppHomeHandler.java
+++ b/src/main/java/com/statusbeat/statusbeat/slack/AppHomeHandler.java
@@ -43,6 +43,8 @@ public class AppHomeHandler {
     @PostConstruct
     public void registerHandlers() {
         registerAppHomeOpenedEvent();
+        registerStartSyncAction();
+        registerStopSyncAction();
         registerEnableSyncAction();
         registerDisableSyncAction();
         registerManualSyncAction();
@@ -69,6 +71,48 @@ public class AppHomeHandler {
                 return ctx.ack();
             } catch (Exception e) {
                 log.error("Error handling app_home_opened event", e);
+                return ctx.ack();
+            }
+        });
+    }
+
+    private void registerStartSyncAction() {
+        slackApp.blockAction("start_sync", (req, ctx) -> {
+            try {
+                String userId = req.getPayload().getUser().getId();
+                log.info("User {} clicked Start Sync", userId);
+
+                Optional<User> userOpt = userService.findBySlackUserId(userId);
+                if (userOpt.isPresent()) {
+                    User user = userOpt.get();
+                    userService.startSync(user.getId());
+                    appHomeService.publishHomeView(userId, ctx.getBotToken());
+                }
+
+                return ctx.ack();
+            } catch (Exception e) {
+                log.error("Error handling start_sync action", e);
+                return ctx.ack();
+            }
+        });
+    }
+
+    private void registerStopSyncAction() {
+        slackApp.blockAction("stop_sync", (req, ctx) -> {
+            try {
+                String userId = req.getPayload().getUser().getId();
+                log.info("User {} clicked Stop Sync", userId);
+
+                Optional<User> userOpt = userService.findBySlackUserId(userId);
+                if (userOpt.isPresent()) {
+                    User user = userOpt.get();
+                    userService.stopSync(user.getId());
+                    appHomeService.publishHomeView(userId, ctx.getBotToken());
+                }
+
+                return ctx.ack();
+            } catch (Exception e) {
+                log.error("Error handling stop_sync action", e);
                 return ctx.ack();
             }
         });


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces enhanced user control over Slack status synchronization, preventing StatusBeat from overwriting a user's status without explicit consent.

Key changes include:

*   **Explicit Sync Activation**: A new `syncActive` setting is introduced. Users must now explicitly "Start Sync" for StatusBeat to begin managing their Slack status, even if the overall sync feature is enabled.
*   **Manual Status Override Detection**: If a user manually changes their Slack status while StatusBeat is actively syncing, StatusBeat will now detect this, set a `manualStatusSet` flag, and automatically *stop* the sync process. This prevents StatusBeat from immediately overwriting the user's manual status.
*   **Protected Manual Statuses**: StatusBeat will no longer clear a user's Slack status if the `manualStatusSet` flag is active, ensuring manual statuses are preserved.
*   **Clear Consent for Sync**: When a user explicitly "Starts Sync" via the app home, the `manualStatusSet` flag is cleared, indicating renewed consent for StatusBeat to manage their status.
*   **Improved Sync State Visibility**: The Slack App Home UI now displays the sync status in three distinct states: "Disabled", "Paused" (enabled but not active), and "Syncing". Corresponding "Start Sync", "Stop Sync", "Enable Sync", and "Disable" buttons are provided for clear control.
*   **Refined Status Clearing Logic**: A `statusCleared` flag is added to track whether StatusBeat has explicitly cleared a user's status or if no StatusBeat status is currently set, preventing redundant clear operations and ensuring StatusBeat only clears statuses it previously set.
*   **Consolidated Sync Conditions**: All conditions for status synchronization (enabled, active, within working hours, no manual override) are now checked through a single gate, improving the robustness and clarity of the sync logic.
<!-- kody-pr-summary:end -->