### PR TITLE
docs: sync README and .env.example with current endpoints and versions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 SLACK_CLIENT_ID=your_slack_client_id_here
 SLACK_CLIENT_SECRET=your_slack_client_secret_here
 SLACK_SIGNING_SECRET=your_slack_signing_secret_here
-SLACK_REDIRECT_URI=http://localhost:8080/oauth/slack/callback
+SLACK_REDIRECT_URI=http://localhost:8080/slack/oauth_redirect
 
 # Spotify Configuration
 # Get these from https://developer.spotify.com/dashboard

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # StatusBeat
 
 ![Java](https://img.shields.io/badge/Java-25-orange)
-![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.2-brightgreen)
+![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.1.0-brightgreen)
 ![MongoDB](https://img.shields.io/badge/MongoDB-8.0-green)
 ![Slack API](https://img.shields.io/badge/Slack-API-4A154B)
 ![Spotify API](https://img.shields.io/badge/Spotify-API-1DB954)
@@ -28,7 +28,7 @@ Automatically sync your currently playing Spotify music with your Slack status.
 
 ## Tech Stack
 
-- **Backend**: Java 25 + Spring Boot 4.0.2
+- **Backend**: Java 25 + Spring Boot 4.1.0
 - **Database**: MongoDB
 - **APIs**: Slack API, Spotify Web API
 - **Security**: OAuth2, Spring Security, AES-256 encryption
@@ -58,7 +58,7 @@ Create a `.env` file:
 SLACK_CLIENT_ID=your_slack_client_id
 SLACK_CLIENT_SECRET=your_slack_client_secret
 SLACK_SIGNING_SECRET=your_slack_signing_secret
-SLACK_REDIRECT_URI=http://localhost:8080/oauth/slack/callback
+SLACK_REDIRECT_URI=http://localhost:8080/slack/oauth_redirect
 
 # Spotify Configuration
 SPOTIFY_CLIENT_ID=your_spotify_client_id
@@ -141,7 +141,9 @@ statusbeat.sync.polling-interval=10000
 ```
 src/main/java/com/statusbeat/statusbeat/
 ├── config/          # Configuration classes
-├── controller/      # REST controllers
+├── constants/       # Shared constants
+├── controller/      # Web and OAuth controllers
+├── exception/       # Custom exceptions
 ├── model/           # MongoDB entities
 ├── repository/      # Data access layer
 ├── service/         # Business logic
@@ -188,11 +190,15 @@ Update redirect URIs in Slack and Spotify apps to use your deployed URL.
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/` | GET | Home page |
-| `/oauth/slack` | GET | Initiate Slack OAuth |
-| `/oauth/slack/callback` | GET | Slack OAuth callback |
+| `/success` | GET | Connection success page |
+| `/error` | GET | Connection error page |
+| `/privacy` | GET | Privacy policy |
+| `/support` | GET | Support page |
+| `/slack/install` | GET | Initiate Slack OAuth |
+| `/slack/oauth_redirect` | GET | Slack OAuth callback |
+| `/slack/events` | POST | Slack events endpoint |
 | `/oauth/spotify` | GET | Initiate Spotify OAuth |
 | `/oauth/spotify/callback` | GET | Spotify OAuth callback |
-| `/slack/events` | POST | Slack events endpoint |
 | `/health` | GET | Health check |
 
 ## Contributing


### PR DESCRIPTION
## Summary
Update README and `.env.example` to match the current codebase.

## Changes
- Bump Spring Boot references to `4.0.5` (badge + Tech Stack).
- Fix Slack redirect URI to `/slack/oauth_redirect` in README and `.env.example` (old `/oauth/slack/callback` never existed — Slack OAuth is handled by Bolt's servlet).
- Add `constants/` and `exception/` packages to the architecture tree.
- Fix API Endpoints table: replace non-existent `/oauth/slack` paths with `/slack/install` and `/slack/oauth_redirect`; add `/success`, `/error`, `/privacy`, `/support` pages.

## Testing
Docs only — no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions and example environment values for the new Slack OAuth redirect path.
  * Refreshed the README with the latest version badges and an updated project structure overview.
  * Expanded the listed routes to include additional public pages and Slack-related endpoints, with the revised URL format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->